### PR TITLE
Fix flipping multiple times

### DIFF
--- a/app/Actions/Frontend/LoadCampaignAction.php
+++ b/app/Actions/Frontend/LoadCampaignAction.php
@@ -18,8 +18,8 @@ class LoadCampaignAction
         ]);
 
         $message = match(true) {
-            $campaign->hasNotStarted() => 'This Campaign has not started yet! Please check back later 😀',
-            $campaign->hasEnded() => 'This Campaign has ended. Please select another Campaign to play 🥲',
+            $campaign->hasNotStarted() => 'Campaign has not started yet',
+            $campaign->hasEnded() => 'Campaign has ended',
             default => null
         };
 

--- a/app/Actions/Frontend/LoadCampaignAction.php
+++ b/app/Actions/Frontend/LoadCampaignAction.php
@@ -31,7 +31,7 @@ class LoadCampaignAction
         return json_encode([
             'apiPath' => '/api/flip',
             'gameId' => $game->id,
-            'revealedTiles' => $tiles,
+            'reveledTiles' => $tiles,
             'message' => $message
 		]);
 	}

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -523,6 +523,11 @@ class TileComponent extends Component {
         this.refs.image.src = src;
         this.root.classList.toggle(classes.tileVisible, true);
     }
+
+    // Custom Implementation by Segun Olaiya
+    hasImage() {
+        return !!this.refs.image?.src?.trim();
+    }
 }
 class PopupComponent extends Component {
     render() {
@@ -554,7 +559,8 @@ class MainComponent extends Component {
     }
     handleTileClick(index) {
         return __awaiter(this, void 0, void 0, function* () {
-            if (!this._interactive) {
+           // Custom Implementation by Segun Olaiya
+            if (!this._interactive || this._tiles[index].hasImage()) {
                 return;
             }
             this._interactive = false;


### PR DESCRIPTION
### Description
Noticed that it is possible to flip an already flipped tile, I don't think that should be the case. This PR adds support for checking if the tile has already been flipped.

Also the instructions says to pass `revealedTiles` key in the `config` - but the `game.js` is expecting `reveledTiles`. For this reason, this PR passes `reveledTiles` from the frontend.